### PR TITLE
feat: auto-update README.md

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,33 @@
+name: update-readme
+
+# author: @MikeRalphson
+# based on https://github.com/victoriadrake/victoriadrake/blob/master/.github/workflows/update.yaml
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 23 * * *'
+  workflow_dispatch: {}
+  
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🍽️ Get working copy
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+      - name: 🍳 Shake & bake README
+        run: |
+          npm i
+          node ./scripts/update.js ${{ secrets.GITHUB_TOKEN }}
+      - name: 🚀 Deploy
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git add .
+          git diff-index --quiet HEAD || git commit -am "Update dynamic content"
+          git push --all -f https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The Linux Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -12,27 +12,36 @@ We are just getting started with this effort to external project work, so this p
 
 Feel free to suggest a new project by submitting an issue, or roll up your sleeves and get involved in a specific project by jumping in on the issues or the discussions for each area of work.
 
+<!-- dynamic content -->
 ## Active Projects
-These are the projects currently being moved forward in some capacity. Each project has a listing of to do, in progress, and done tasks, as well as link to any open issues or discussions.
+These are the projects currently being moved forward in some capacity. Each project has a listing of to-do, in progress, and done tasks, as well as link to any open issues or discussions.
 
-- [**Member Showcase & Engagement**](https://github.com/OAI/Projects/projects/2) - Continually improving our showcasing and engagement with our members while actively working to recruit new ones.
-- [**Profile & Engage with API Providers**](https://github.com/OAI/Projects/projects/3) - Work to identify, profile, and build relationships with API providers who have implemented the OpenAPI specification.
-- [**Profile and Engage with Open Source Tooling**](https://github.com/OAI/Projects/projects/4) - Establish an official directory of open source tooling that uses OAS, and actively work to establish and build relationships with them.
-- [**Business Sector Showcase & Engagement**](https://github.com/OAI/Projects/projects/5) - Work to profile different business sectors that are putting OpenAPI to work, then engage, and build relationships with individuals or organizations.
-- [**Quantify the Scope of the OpenAPI Community**](https://github.com/OAI/Projects/projects/6) - Work to establish the size and scope of the OpenAPI community and then track on the growth over time.
-- [**Curate and Publish API Videos**](https://github.com/OAI/Projects/projects/8) - Work to discover, curate, and then showcase the existing videos that exist about OpenAPI.
-- [**OpenAPI Search Engine Optimization**](https://github.com/OAI/Projects/projects/11) - This is ongoing work to help improve the search engine optimization for the OAI and OAS, helping increase it's presence.
-- [**Additional OAI Leadership**](https://github.com/OAI/Projects/projects/9) - Work to define the roles for 3 additional leadership within the OAI, and help them be successful in work over a year.
-- [**Strengthen Multi-Specification Relationships**](https://github.com/OAI/Projects/projects/7) - Ongoing work to help strengthen the relationships between the OAI and other API specifications like AsyncAPI, GraphQL, JSON Schema, and gRPC.
-- [**JSON Schema Documentation Update**](https://github.com/OAI/Projects/projects/10) - This is work to invest in the updating of JSON Schema documentation, helping invest in supporting specifications.
+Project|Description|
+|---|---|
+|[**Member Showcase & Engagement**](https://github.com/OAI/Projects/projects/2)|Continually improving our showcasing and engagement with our members while actively working to recruit new ones.|
+|[**Profile & Engage with API Providers**](https://github.com/OAI/Projects/projects/3)|Work to identify, profile, and build relationships with API providers who have implemented the OpenAPI specification.|
+|[**Profile and Engage with Open Source Tooling**](https://github.com/OAI/Projects/projects/4)|Establish an official directory of open source tooling that uses OAS, and actively work to establish and build relationships with them.|
+|[**Business Sector Showcase & Engagement**](https://github.com/OAI/Projects/projects/5)|Work to profile different business sectors that are putting OpenAPI to work, then engage, and build relationships with individuals or organizations.|
+|[**Quantify the Scope of the OpenAPI Community**](https://github.com/OAI/Projects/projects/6)|Work to establish the size and scope of the OpenAPI community and then track on the growth over time.|
+|[**Strengthen Multi-Specification Relationships**](https://github.com/OAI/Projects/projects/7)|Ongoing work to help strengthen the relationships between the OAI and other API specifications like AsyncAPI, GraphQL, JSON Schema, and gRPC.|
+|[**Curate and Publish API Videos**](https://github.com/OAI/Projects/projects/8)|Work to discover, curate, and then showcase the existing videos that exist about OpenAPI.|
+|[**Additional OAI Leadership**](https://github.com/OAI/Projects/projects/9)|Work to define the roles for 3 additional leadership within the OAI, and help them be successful in work over a year.|
+|[**JSON Schema Documentation Update**](https://github.com/OAI/Projects/projects/10)|This is work to invest in the updating of JSON Schema documentation, helping invest in supporting specifications.|
+|[**OpenAPI Search Engine Optimization**](https://github.com/OAI/Projects/projects/11)|This is ongoing work to help improve the search engine optimization for the OAI and OAS, helping increase it's presence.|
+|[**Overlays**](https://github.com/OAI/Projects/projects/17)|This is to track on all the moving parts of the overlays conversation.|
+|[**Pitch Deck**](https://github.com/OAI/Projects/projects/19)|Track what is happening.|
 
 ## Incubator Projects
 
-- [**OpenAPI Initiative Incubator Project Proposal Process**](https://github.com/OAI/Projects/projects/12) - This is a ongoing project ot help move forward the process that governs any incubator project added to the OpenAPI Initiative (OAI).
-- [**Workflow and Automation Incubator Project**](https://github.com/OAI/Projects/projects/13) - This is a project to manage the workflow and automation incubator project proposal and effort once it is accepted by the TOB.
-- [**Security Incubator Project**](https://github.com/OAI/Projects/projects/14) - This is a project to manage the security incubator project proposal and effort once it is accepted by the TOB.
-- [**SLA Incubator Project**](https://github.com/OAI/Projects/projects/15) - This is a project to manage the security incubator project proposal and effort once it is accepted by the TOB.
-- [**Travel Journey Incubator Project**](https://github.com/OAI/Projects/projects/16) - This is a project to manage the airline, hospitality, rail, and travel incubator project proposal and effort once it is accepted by the TOB.
+Project|Description|
+|---|---|
+|[**OpenAPI Initiative Incubator Project Proposal Process**](https://github.com/OAI/Projects/projects/12)|This is a ongoing project ot help move forward the process that governs any incubator project added to the OpenAPI Initiative (OAI).|
+|[**Workflow and Automation Incubator Project**](https://github.com/OAI/Projects/projects/13)|This is a project to manage the workflow and automation incubator project proposal and effort once it is accepted by the TOB.|
+|[**Security Incubator Project**](https://github.com/OAI/Projects/projects/14)|This is a project to manage the security incubator project proposal and effort once it is accepted by the TOB.|
+|[**SLA Incubator Project**](https://github.com/OAI/Projects/projects/15)|This is a project to manage the security incubator project proposal and effort once it is accepted by the TOB.|
+|[**Travel Journey Incubator Project**](https://github.com/OAI/Projects/projects/16)|This is a project to manage the airline, hospitality, rail, and travel incubator project proposal and effort once it is accepted by the TOB.|
+|[**Healthcare Incubator Project**](https://github.com/OAI/Projects/projects/18)|This is a project to setup a working group to focus on the healthcare industry.|
+<!-- dynamic content -->
 
 As projects are complete they will be closed, with some projects living on forever and issues and discussions being used to drive ongoing work.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "oai-projects",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "oai-projects",
+  "version": "1.0.0",
+  "description": "This is a repo for moving forward a variety of projects within the OpenAPI community. In an effort to be more transparent and help involve the community in a variety of ways we will be managing most projects within this repository. This README should provide you with everything you need to get started working on an existing project, or suggest a new project.",
+  "main": "index.js",
+  "dependencies": {
+    "node-fetch": "^2.6.1"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OAI/Projects.git"
+  },
+  "keywords": [],
+  "author": "Kin Lane",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/OAI/Projects/issues"
+  },
+  "homepage": "https://github.com/OAI/Projects#readme"
+}

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+
+const fetch = require('node-fetch');
+
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true, rejectUnauthorized: false });
+const bobwAgent = function(_parsedURL) {
+  if (_parsedURL.protocol == 'http:') {
+    return httpAgent;
+  } else {
+    return httpsAgent;
+  }
+};
+
+const token = process.env['GH_TOKEN'] || process.argv[2];
+const auth = 'Basic ' + Buffer.from(process.env.GITHUB_ACTOR+ ':' + token).toString('base64');
+const delimiter = '<!-- dynamic content -->\n';
+
+let md = '';
+
+function append(s = ''){
+  md += s + '\n';
+  return md;
+}
+
+async function main() {
+  const u = `https://api.github.com/repos/OAI/Projects/projects`;
+  try {
+     const res = await fetch(u,{ agent: bobwAgent, headers: { 'Accept': 'application/vnd.github.inertia-preview+json', 'User-Agent': 'mermade', Authorization: auth }  });
+     const p = await res.json();
+     append('## Active Projects');
+     append('These are the projects currently being moved forward in some capacity. Each project has a listing of to-do, in progress, and done tasks, as well as link to any open issues or discussions.');
+     append();
+     append('Project|Description|');
+     append('|---|---|');
+     for (let project of p) {
+       if (project.state === 'open' && project.name.indexOf('Incubator')<0) {
+          append(`|[**${project.name}**](${project.html_url})|${project.body}|`);
+       }
+     }
+     append();
+     append('## Incubator Projects');
+     append();
+     append('Project|Description|');
+     append('|---|---|');
+     for (let project of p) {
+       if (project.state === 'open' && project.name.indexOf('Incubator')>=0) {
+          append(`|[**${project.name}**](${project.html_url})|${project.body}|`);
+       }
+     }
+
+     let readme = fs.readFileSync('./README.md','utf8');
+     readme = readme.split(delimiter);
+     readme = readme[0] + delimiter + md + delimiter + readme[2];
+     fs.writeFileSync('./README.md',readme,'utf8');
+  }
+  catch (ex) {
+    console.warn(ex.message);
+  }
+}
+
+main();


### PR DESCRIPTION
As discussed, this PR adds a GitHub Action which once a day, automatically updates the `README.md` with the list of open Projects in two tables  - incubator and non-incubator, based on the project title. The Action can also be run manually.

It also adds an Apache-2.0 `LICENSE` file.